### PR TITLE
refactor: centralize app constants

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:dummy_app/core/routers/page-routers/routers.dart';
 import 'package:dummy_app/core/services/local-storage/opened-page/local_storage.dart';
+import 'package:dummy_app/core/constants.dart';
 import 'package:dummy_app/presentation/screens/assessment/analyze_assessment.dart';
 import 'package:dummy_app/presentation/screens/assessment/assessments/q2/assessment_task_screen.dart';
 import 'package:dummy_app/presentation/screens/assessment/start_assesment.dart';
@@ -39,10 +40,10 @@ class _MyApp extends State<MyApp>{
     });
   }
 
-  String _initialRoute = '/loading';
+  String _initialRoute = AppRoutes.loading;
 
   Future<void> _loadInitialRoute() async {
-    final lastRoute = await getCurrentRoute() ?? '/home';
+    final lastRoute = await getCurrentRoute() ?? AppRoutes.home;
 
     if (!mounted) return; // prevent calling setState after dispose
     setState(() {

--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AppRoutes {
+  static const String loading = '/loading';
+  static const String home = '/home';
+}
+
+class AppAssets {
+  static const String mascotTransparent = 'assets/mascot/mascot-transparent.png';
+  static const String mascot = 'assets/mascot.png';
+  static const String backButton = 'assets/images/back-btn.png';
+  static const String letsStartMessage = 'assets/svgs/lets-start-message.svg';
+  static const String emailOption = 'assets/svgs/email-option.svg';
+  static const String phoneOption = 'assets/svgs/phone-option.svg';
+  static const String arrowRightCutout = 'assets/images/ArrowRight-cutout.png';
+  static const String iconHome = 'assets/icons/home.png';
+  static const String iconMap = 'assets/icons/map.png';
+  static const String iconDumble = 'assets/icons/dumble.png';
+  static const String iconPosition = 'assets/icons/position.png';
+  static const String iconBars = 'assets/icons/bars.png';
+  static const String iconCheck = 'assets/icons/check.png';
+  static const String iconDash = 'assets/icons/dash.png';
+  static const String error = 'assets/images/error.png';
+}
+
+class AppColors {
+  static const Color mainColor = Color(0xFFFA845C);
+  static const Color mainTextColor = Color(0xFF42080A);
+  static const Color inputBackground = Color(0xFFFEE3D6);
+  static const Color mainLightColor = Color(0xFFFEE3D6);
+}

--- a/lib/core/services/local-storage/opened-page/local_storage.dart
+++ b/lib/core/services/local-storage/opened-page/local_storage.dart
@@ -1,4 +1,5 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:dummy_app/core/constants.dart';
 
 Future<void> saveCurrentRoute(String route) async {
   final prefs = await SharedPreferences.getInstance();
@@ -7,6 +8,6 @@ Future<void> saveCurrentRoute(String route) async {
 
 Future<String> getCurrentRoute() async {
   final prefs = await SharedPreferences.getInstance();
-  final lastRoute = prefs.getString('last_route') ?? '/home';
+  final lastRoute = prefs.getString('last_route') ?? AppRoutes.home;
   return lastRoute;
 }

--- a/lib/core/themes.dart
+++ b/lib/core/themes.dart
@@ -1,8 +1,1 @@
-import 'package:flutter/material.dart';
-
-class AppColors {
-  static const Color mainColor = Color(0xFFFA845C);
-  static const Color mainTextColor = Color(0xFF42080A);
-  static const Color inputBackground = Color(0xFFFEE3D6);
-  static const Color mainLightColor = Color(0xFFFEE3D6);
-}
+export 'constants.dart';

--- a/lib/presentation/screens/assessment/assessments/q10/assessment_correct_screen.dart
+++ b/lib/presentation/screens/assessment/assessments/q10/assessment_correct_screen.dart
@@ -94,7 +94,7 @@ class _A10CorrectScreen extends State<A10CorrectScreen>{
                       margin: const EdgeInsets.only(top: 50.0),
                       alignment: Alignment.center,
                       child: Image.asset(
-                        'assets/mascot/mascot-transparent.png',
+                        AppAssets.mascotTransparent,
                         width: 250,
                         height: 250,
                       ),

--- a/lib/presentation/screens/assessment/assessments/q3/assessment_correct_screen.dart
+++ b/lib/presentation/screens/assessment/assessments/q3/assessment_correct_screen.dart
@@ -59,7 +59,7 @@ class _A3CorrectScreen extends State<A3CorrectScreen>{
                   margin: const EdgeInsets.only(top: 50.0),
                   alignment: Alignment.center,
                   child: Image.asset(
-                    'assets/mascot/mascot-transparent.png',
+                    AppAssets.mascotTransparent,
                     width: 150,
                     height: 150,
                   ),

--- a/lib/presentation/screens/assessment/start_assesment.dart
+++ b/lib/presentation/screens/assessment/start_assesment.dart
@@ -38,7 +38,7 @@ class StartAssesmentScreen extends StatelessWidget {
                 child: GestureDetector(
                   onTap: () => goToFillProfile(context),
                   child: Image.asset(
-                    'assets/images/back-btn.png',
+                    AppAssets.backButton,
                     width: 150,
                     height: 150,
                   ),
@@ -50,7 +50,7 @@ class StartAssesmentScreen extends StatelessWidget {
                 padding: const EdgeInsets.only(left: 15.0, right: 15.0),
                 margin: const EdgeInsets.only(top: 10.0),
                 alignment: Alignment.center,
-                child: SvgPicture.asset('assets/svgs/lets-start-message.svg',),
+                child: SvgPicture.asset(AppAssets.letsStartMessage,),
 
               ),
 
@@ -75,7 +75,7 @@ class StartAssesmentScreen extends StatelessWidget {
                 margin: const EdgeInsets.only(top: 50.0),
                 alignment: Alignment.center,
                 child: Image.asset(
-                  'assets/mascot/mascot-transparent.png',
+                  AppAssets.mascotTransparent,
                   width: 150,
                   height: 150,
                 ),

--- a/lib/presentation/screens/auth/email/email_register_screen.dart
+++ b/lib/presentation/screens/auth/email/email_register_screen.dart
@@ -368,7 +368,7 @@ class _EmailRegisterScreen extends State<EmailRegisterScreen> {
                             Container(
                               margin: EdgeInsets.only(left: 10.0),
                               child: Image.asset(
-                                "assets/images/ArrowRight-cutout.png",
+                                AppAssets.arrowRightCutout,
                               ),
                             ),
 

--- a/lib/presentation/screens/auth/options/login_option_screen.dart
+++ b/lib/presentation/screens/auth/options/login_option_screen.dart
@@ -63,7 +63,7 @@ class LoginOptionScreen extends StatelessWidget{
                       child: Stack(
                         children: [
                           SvgPicture.asset(
-                            'assets/svgs/email-option.svg',
+                            AppAssets.emailOption,
                             height: 170,
                             width: 170,
                           ),
@@ -83,7 +83,7 @@ class LoginOptionScreen extends StatelessWidget{
                   ),
 
                   Image.asset(
-                    'assets/mascot/mascot-transparent.png',
+                    AppAssets.mascotTransparent,
                     width: 70,  // 80% of screen width
                     height: 70,
                   ),
@@ -97,7 +97,7 @@ class LoginOptionScreen extends StatelessWidget{
                       child: Stack(
                         children: [
                           SvgPicture.asset(
-                            'assets/svgs/phone-option.svg',
+                            AppAssets.phoneOption,
                             height: 170,
                             width: 170,
                           ),

--- a/lib/presentation/screens/auth/options/register_option_screen.dart
+++ b/lib/presentation/screens/auth/options/register_option_screen.dart
@@ -64,7 +64,7 @@ class RegisterOptionScreen extends StatelessWidget{
                       child: Stack(
                         children: [
                           SvgPicture.asset(
-                            'assets/svgs/email-option.svg',
+                            AppAssets.emailOption,
                             height: 170,
                             width: 170,
                           ),
@@ -85,7 +85,7 @@ class RegisterOptionScreen extends StatelessWidget{
 
 
                     Image.asset(
-                      'assets/mascot/mascot-transparent.png',
+                      AppAssets.mascotTransparent,
                       width: 70,  // 80% of screen width
                       height: 70,
                     ),
@@ -99,7 +99,7 @@ class RegisterOptionScreen extends StatelessWidget{
                       child: Stack(
                         children: [
                           SvgPicture.asset(
-                            'assets/svgs/phone-option.svg',
+                            AppAssets.phoneOption,
                             height: 170,
                             width: 170,
                           ),

--- a/lib/presentation/screens/auth/phone/otp_screen.dart
+++ b/lib/presentation/screens/auth/phone/otp_screen.dart
@@ -66,7 +66,7 @@ class _OtpScreen extends State<OtpScreen> {
                 child: GestureDetector(
                 onTap: () => Navigator.pop(context),
                 child: Image.asset(
-                  'assets/images/back-btn.png',
+                  AppAssets.backButton,
                   width: 150,
                   height: 150,
                 ),

--- a/lib/presentation/screens/intro/intro_screen.dart
+++ b/lib/presentation/screens/intro/intro_screen.dart
@@ -2,6 +2,7 @@ import 'package:dummy_app/core/routers/page-routers/routers.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/themes.dart';
+import 'package:dummy_app/core/constants.dart';
 
 class IntroScreen extends StatefulWidget{
   const IntroScreen({super.key});
@@ -39,7 +40,7 @@ class _IntroScreen extends State<IntroScreen>{
                     // padding: const EdgeInsets.only(left: 15.0, right: 15.0),
                     margin: const EdgeInsets.only(top: 80.0),
                     child: Image.asset(
-                      'assets/mascot/mascot-transparent.png',
+                      AppAssets.mascotTransparent,
                       width: MediaQuery.of(context).size.width * 0.1,  // 80% of screen width
                       height: MediaQuery.of(context).size.height * 0.1,
                     ),

--- a/lib/presentation/screens/splash_screen.dart
+++ b/lib/presentation/screens/splash_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'home_screen.dart';
 import 'auth/email/email_login_screen.dart';
 import 'auth/email/email_register_screen.dart';
+import 'package:dummy_app/core/constants.dart';
 
 class SplashScreen extends StatefulWidget{
   const SplashScreen({super.key});
@@ -47,7 +48,7 @@ class _SplashScreen extends State<SplashScreen> with SingleTickerProviderStateMi
             children: [
               Container(
                 child: Image.asset(
-                  'assets/mascot-transparent.png',
+                  AppAssets.mascotTransparent,
                   width: MediaQuery.of(context).size.width * 0.7,  // 80% of screen width
                   height: MediaQuery.of(context).size.height * 0.3,
                 ),

--- a/lib/presentation/screens/user/profile/profile_screen.dart
+++ b/lib/presentation/screens/user/profile/profile_screen.dart
@@ -88,7 +88,7 @@ class _ProfileScreen extends State<ProfileScreen>{
                             ),
                             shape: BoxShape.circle,
                             image: DecorationImage(
-                              image: AssetImage('assets/mascot.png'),
+                              image: AssetImage(AppAssets.mascot),
                               fit: BoxFit.contain, // Adjust the fit as needed
                             ),
                           ),

--- a/lib/presentation/widgets/loaders/assessment-loader/assessment_loader.dart
+++ b/lib/presentation/widgets/loaders/assessment-loader/assessment_loader.dart
@@ -31,7 +31,7 @@ class AssessmentLoader  extends StatelessWidget {
               )),
         ),
         Image.asset(
-          'assets/mascot/mascot-transparent.png', // replace with your asset path
+          AppAssets.mascotTransparent,
           width: 100,
           height: 100,
           fit: BoxFit.contain,

--- a/lib/presentation/widgets/messages/errors/error.dart
+++ b/lib/presentation/widgets/messages/errors/error.dart
@@ -16,7 +16,7 @@ class AssessmentErrorWidget extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Image.asset(
-            'assets/images/error.png', // replace with your asset path
+            AppAssets.error,
             width: 100,
             height: 100,
             fit: BoxFit.contain,

--- a/lib/presentation/widgets/navigation/bottom/navigation.dart
+++ b/lib/presentation/widgets/navigation/bottom/navigation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:dummy_app/core/constants.dart';
 
 class BottomNavigator extends StatelessWidget {
   final int currentIndex;
@@ -19,27 +20,27 @@ class BottomNavigator extends StatelessWidget {
       unselectedItemColor: Colors.grey,
       items: [
         BottomNavigationBarItem(
-          icon:  Image.asset("assets/icons/home.png"),
+          icon:  Image.asset(AppAssets.iconHome),
           label: "",
         ),
 
         BottomNavigationBarItem(
-          icon:  Image.asset("assets/icons/map.png"),
+          icon:  Image.asset(AppAssets.iconMap),
           label: "",
         ),
 
         BottomNavigationBarItem(
-          icon:  Image.asset("assets/icons/dumble.png"),
+          icon:  Image.asset(AppAssets.iconDumble),
           label: "",
         ),
 
         BottomNavigationBarItem(
-          icon:  Image.asset("assets/icons/position.png"),
+          icon:  Image.asset(AppAssets.iconPosition),
           label: "",
         ),
 
         BottomNavigationBarItem(
-          icon:  Image.asset("assets/icons/bars.png"),
+          icon:  Image.asset(AppAssets.iconBars),
           label: "",
         ),
       ],

--- a/lib/presentation/widgets/navigation/navigation.dart
+++ b/lib/presentation/widgets/navigation/navigation.dart
@@ -39,7 +39,7 @@ class NavigationBarDrawer extends StatelessWidget {
                     ),
                     shape: BoxShape.circle,
                     image: DecorationImage(
-                      image: AssetImage('assets/mascot.png'),
+                      image: AssetImage(AppAssets.mascot),
                       fit: BoxFit.cover, // Adjust the fit as needed
                     ),
                   ),

--- a/lib/presentation/widgets/tasks/task.dart
+++ b/lib/presentation/widgets/tasks/task.dart
@@ -60,7 +60,7 @@ class WeeklyTaskList extends StatelessWidget {
 
 
                     Image.asset(
-                      task.done? "assets/icons/check.png": "assets/icons/dash.png",
+                      task.done ? AppAssets.iconCheck : AppAssets.iconDash,
 
                     )
                     


### PR DESCRIPTION
## Summary
- define route names, asset paths, and theme colors in `AppConstants`
- replace hard-coded strings with shared constants across screens and widgets
- re-export constants from `themes.dart` for existing imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a93ff1d08833394a6805e46a31eb6