### PR TITLE
Persist current route and load initial route

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,23 +1,14 @@
-import 'package:dummy_app/core/routers/page-routers/routers.dart';
-import 'package:dummy_app/core/services/local-storage/opened-page/local_storage.dart';
 import 'package:dummy_app/core/constants.dart';
-import 'package:dummy_app/presentation/screens/assessment/analyze_assessment.dart';
-import 'package:dummy_app/presentation/screens/assessment/assessments/q2/assessment_task_screen.dart';
-import 'package:dummy_app/presentation/screens/assessment/start_assesment.dart';
-import 'package:dummy_app/presentation/screens/home_screen.dart';
+import 'package:dummy_app/core/routers/route_persistence_observer.dart';
+import 'package:dummy_app/core/services/local-storage/opened-page/local_storage.dart';
 import 'package:dummy_app/presentation/screens/auth/options/login_option_screen.dart';
-import 'package:dummy_app/presentation/screens/user/profile/fill_profile_screen.dart';
+import 'package:dummy_app/presentation/screens/home_screen.dart';
+import 'package:dummy_app/presentation/screens/splash_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'presentation/screens/splash_screen.dart';
-import 'presentation/screens/auth/email/email_register_screen.dart';
-import 'presentation/screens/auth/email/email_login_screen.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import '../../l10n/app_localizations.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:intl/intl.dart';
-import 'presentation/screens/auth/options/register_option_screen.dart';
+import '../../l10n/app_localizations.dart';
 
 class MyApp extends StatefulWidget{
   const MyApp({super.key});
@@ -51,13 +42,18 @@ class _MyApp extends State<MyApp>{
     });
   }
 
+  @override
+  void initState() {
+    super.initState();
+    _loadInitialRoute();
+  }
+
 
   @override
   Widget build(BuildContext context){
 
 
     return MaterialApp(
-
       theme: ThemeData(
         textTheme: GoogleFonts.dmSansTextTheme()
       ),
@@ -65,15 +61,19 @@ class _MyApp extends State<MyApp>{
       localizationsDelegates:  AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       locale: _locale,
-      home: Scaffold(
-        body: AuthCheck() // AnalyzeAssessmentScreen() //    // StartAssesmentScreen()   AssessmentScreen()
-      ),
-
+      initialRoute: _initialRoute,
+      routes: {
+        AppRoutes.loading: (_) => const SplashScreen(),
+        AppRoutes.home: (_) => Scaffold(body: const AuthCheck()),
+      },
+      navigatorObservers: [RoutePersistenceObserver()],
     );
   }
 }
 
 class AuthCheck extends StatelessWidget {
+  const AuthCheck({super.key});
+
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<User?>(

--- a/lib/core/routers/page-routers/routers.dart
+++ b/lib/core/routers/page-routers/routers.dart
@@ -38,7 +38,6 @@ import 'package:dummy_app/presentation/screens/assessment/assessments/q9/assessm
 import 'package:dummy_app/presentation/screens/assessment/start_assesment.dart';
 import 'package:dummy_app/presentation/screens/auth/email/email_login_screen.dart';
 import 'package:dummy_app/presentation/screens/auth/email/email_register_screen.dart';
-import 'package:dummy_app/presentation/screens/home_screen.dart';
 import 'package:dummy_app/presentation/screens/auth/options/login_option_screen.dart';
 import 'package:dummy_app/presentation/screens/auth/phone/otp_screen.dart';
 import 'package:dummy_app/presentation/screens/auth/phone/phone_login_screen.dart';
@@ -50,12 +49,11 @@ import 'package:dummy_app/presentation/screens/user/dasboard/dashboard_screen.da
 import 'package:dummy_app/presentation/screens/user/profile/fill_profile_screen.dart';
 import 'package:dummy_app/presentation/screens/user/profile/profile_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:dummy_app/core/constants.dart';
 
 
-void goToHome(BuildContext context)=> Navigator.pushReplacement(
-  context,
-  MaterialPageRoute(builder: (_) => HomeScreen()),
-);
+void goToHome(BuildContext context) =>
+    Navigator.pushReplacementNamed(context, AppRoutes.home);
 
 void goToEmailLogin(context) => Navigator.pushReplacement(
   context,

--- a/lib/core/routers/route_persistence_observer.dart
+++ b/lib/core/routers/route_persistence_observer.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/widgets.dart';
+import 'package:dummy_app/core/services/local-storage/opened-page/local_storage.dart';
+
+class RoutePersistenceObserver extends NavigatorObserver {
+  void _save(Route<dynamic>? route) {
+    final name = route?.settings.name;
+    if (name != null) {
+      saveCurrentRoute(name);
+    }
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _save(route);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _save(newRoute);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _save(previousRoute);
+  }
+}


### PR DESCRIPTION
## Summary
- Load last visited route on startup and use it as MaterialApp's `initialRoute`
- Track navigation with a custom `RoutePersistenceObserver` to save routes
- Use named route for `goToHome`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a982639fc8333a9498f4b85d6ce12