### PR TITLE
Center auth loading spinner and use const constructors

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -80,11 +80,13 @@ class AuthCheck extends StatelessWidget {
       stream: FirebaseAuth.instance.authStateChanges(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return CircularProgressIndicator(); // Show loading while checking
+          return const Center(
+            child: CircularProgressIndicator(),
+          ); // Show loading while checking
         } else if (snapshot.hasData) {
-          return HomeScreen(); // User is logged in
+          return const HomeScreen(); // User is logged in
         } else {
-          return LoginOptionScreen(); // User is NOT logged in
+          return const LoginOptionScreen(); // User is NOT logged in
         }
       },
     );


### PR DESCRIPTION
## Summary
- Center auth loading indicator and mark it const
- Use const constructors for HomeScreen and LoginOptionScreen in auth stream

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ab2a46c64833388ee4280c0cb04d1