### PR TITLE
Add auth check widget test with Firebase mocks

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -80,11 +80,13 @@ class AuthCheck extends StatelessWidget {
       stream: FirebaseAuth.instance.authStateChanges(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return CircularProgressIndicator(); // Show loading while checking
+          return const Center(
+            child: CircularProgressIndicator(),
+          ); // Show loading while checking
         } else if (snapshot.hasData) {
-          return HomeScreen(); // User is logged in
+          return const HomeScreen(); // User is logged in
         } else {
-          return LoginOptionScreen(); // User is NOT logged in
+          return const LoginOptionScreen(); // User is NOT logged in
         }
       },
     );


### PR DESCRIPTION
## Summary
- add helper to mock Firebase channels for tests
- replace counter sample with auth check widget test verifying loader and login screen

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ab2a46c64833388ee4280c0cb04d1